### PR TITLE
sfneal/actions v2.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,8 @@ All notable changes to `crud-model-actions` will be documented in this file
 ## 0.8.1 - 2021-03-30
 - fix sfneal packages version syntax
 - fix Travis CI config to enable code coverage uploads
+
+
+## 0.9.0 - 2021-03-31
+- bump min sfneal/actions version to 2.0
+- fix return type hinting in `CrudModelAction::execute()` method

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.3",
         "laravel/framework": ">=5.0",
-        "sfneal/actions": "^1.0",
+        "sfneal/actions": "^2.0",
         "sfneal/js-response-helpers": "^1.0",
         "sfneal/laravel-helpers": "^2.0",
         "sfneal/models": "^1.3",

--- a/src/CrudModelAction.php
+++ b/src/CrudModelAction.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Sfneal\Actions\AbstractAction;
+use Sfneal\Actions\Action;
 use Sfneal\CrudModelActions\Utils\HandleModel;
 use Sfneal\CrudModelActions\Utils\HttpResponses;
 use Sfneal\CrudModelActions\Utils\ModelEvents;
@@ -14,7 +14,7 @@ use Sfneal\CrudModelActions\Utils\ModelQueries;
 use Sfneal\CrudModelActions\Utils\ResponseMessages;
 use Sfneal\Helpers\Laravel\AppInfo;
 
-abstract class CrudModelAction extends AbstractAction
+abstract class CrudModelAction extends Action
 {
     // todo: artisan command to create new CrudModelAction?
     // todo: change model type hinting to AbstractModel
@@ -51,7 +51,7 @@ abstract class CrudModelAction extends AbstractAction
      * @return Response
      * @throws Exception
      */
-    public function execute()
+    public function execute(): Response
     {
         // Attempt to pass validation check
         // & execute CRUD action on $model


### PR DESCRIPTION
- bump min sfneal/actions version to 2.0
- fix return type hinting in `CrudModelAction::execute()` method