### PR TITLE
sfneal/models v2.3.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,7 @@ All notable changes to `crud-model-actions` will be documented in this file
 
 ## 0.12.0 - 2021-06-08
 - refactor `failMessage()` method to allow for declaring fail messages during run time
+
+
+## 0.12.1 - 2021-06-10
+- bump sfneal/models min version to v2.3.0 to fix issues with `CrudModelAction` exception throwing

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "sfneal/actions": "^2.0",
         "sfneal/js-response-helpers": "^1.0",
         "sfneal/laravel-helpers": "^2.0",
-        "sfneal/models": "^2.0",
+        "sfneal/models": "^2.3",
         "sfneal/observables": "^1.0"
     },
     "require-dev": {

--- a/src/CrudModelAction.php
+++ b/src/CrudModelAction.php
@@ -80,7 +80,7 @@ abstract class CrudModelAction extends Action
             // Validation failed - throw exception
             else {
                 // todo: add exception logging?
-                throw new Exception();
+                throw new Exception($this->failMessage());
             }
         }
 

--- a/src/Utils/ResponseMessages.php
+++ b/src/Utils/ResponseMessages.php
@@ -114,6 +114,6 @@ trait ResponseMessages
      */
     private function getModelShortName(): string
     {
-        return (new ResolveModelName($this->model, true))->execute();
+        return (new ResolveModelName($this->model ?? $this->modelClass, true))->execute();
     }
 }


### PR DESCRIPTION
- bump sfneal/models min version to v2.3.0 to fix issues with `CrudModelAction` exception throwing