### PR TITLE
Nullable `CrudModelAction` $request param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,3 +101,7 @@ All notable changes to `crud-model-actions` will be documented in this file
 
 ## 0.12.1 - 2021-06-10
 - bump sfneal/models min version to v2.3.0 to fix issues with `CrudModelAction` exception throwing
+
+
+## 0.13.0 - 2021-06-14
+- refactor `CrudModelAction`'s $request param to be nullable for actions that don't require request data

--- a/src/CrudModelAction.php
+++ b/src/CrudModelAction.php
@@ -33,13 +33,13 @@ abstract class CrudModelAction extends Action
     /**
      * BaseSaveModelAction constructor.
      *
-     * @param Request $request
+     * @param Request|null $request
      * @param int|EloquentModel|null $model
      * @param int|null $related_model_key
      */
-    public function __construct(Request $request, $model = null, $related_model_key = null)
+    public function __construct(Request $request = null, $model = null, int $related_model_key = null)
     {
-        $this->request = $request;
+        $this->request = $request ?? request();
         $this->model = $this->resolveModel($model);
         $this->related_model_key = $related_model_key;
         $this->setTrackingEventFromConfig();

--- a/src/Utils/ResponseMessages.php
+++ b/src/Utils/ResponseMessages.php
@@ -59,6 +59,7 @@ trait ResponseMessages
     protected function successNoun(string $noun = null): string
     {
         // todo: add spaces to CamelCase $nouns
+        // todo: add ID
         // Set the success noun if passed
         if (isset($noun)) {
             $this->successNoun = $noun;


### PR DESCRIPTION
- refactor `CrudModelAction`'s $request param to be nullable for actions that don't require request data