### PR TITLE
Exception throwing in production environements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,7 @@ All notable changes to `crud-model-actions` will be documented in this file
 
 ## 0.13.0 - 2021-06-14
 - refactor `CrudModelAction`'s $request param to be nullable for actions that don't require request data
+
+
+## 0.14.0 - 2021-06-22
+- fix `CrudModelAction` to throw exceptions when actions fail in dev & prod environments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,3 +109,4 @@ All notable changes to `crud-model-actions` will be documented in this file
 
 ## 0.14.0 - 2021-06-22
 - fix `CrudModelAction` to throw exceptions when actions fail in dev & prod environments
+- cut sfneal/js-response-helpers & sfneal/laravel-helpers from composer dependencies

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,6 @@
         "php": ">=7.3",
         "laravel/framework": ">=5.0",
         "sfneal/actions": "^2.0",
-        "sfneal/js-response-helpers": "^1.0",
-        "sfneal/laravel-helpers": "^2.0",
         "sfneal/models": "^2.3",
         "sfneal/observables": "^1.0"
     },

--- a/src/CrudModelAction.php
+++ b/src/CrudModelAction.php
@@ -88,16 +88,16 @@ abstract class CrudModelAction extends Action
         // CRUD action failed to execute
         catch (Exception $exception) {
 
-            // Throw errors in dev
-            if (AppInfo::isEnvDevelopment()) {
-                throw $exception;
-            }
-
             // Flash a success message
             session()->flash('fail', $this->failMessage());
 
-            // Return failure response
-            return response($this->failResponse(), 200);
+            // Return failure response if the interface is implemented
+            if (method_exists($this, 'failResponse')) {
+                return response($this->failResponse(), 500);
+            }
+
+            // Throw exception
+            throw $exception;
         }
     }
 }

--- a/src/CrudModelAction.php
+++ b/src/CrudModelAction.php
@@ -12,7 +12,6 @@ use Sfneal\CrudModelActions\Utils\HttpResponses;
 use Sfneal\CrudModelActions\Utils\ModelEvents;
 use Sfneal\CrudModelActions\Utils\ModelQueries;
 use Sfneal\CrudModelActions\Utils\ResponseMessages;
-use Sfneal\Helpers\Laravel\AppInfo;
 
 abstract class CrudModelAction extends Action
 {

--- a/src/Interfaces/CrudFailResponder.php
+++ b/src/Interfaces/CrudFailResponder.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\CrudModelActions\Interfaces;
-
 
 trait CrudFailResponder
 {

--- a/src/Interfaces/CrudFailResponder.php
+++ b/src/Interfaces/CrudFailResponder.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Sfneal\CrudModelActions\Interfaces;
+
+
+trait CrudFailResponder
+{
+    /**
+     * Return the default error response.
+     *
+     * @return string
+     */
+    abstract protected function failResponse(): string;
+}

--- a/src/Utils/HttpResponses.php
+++ b/src/Utils/HttpResponses.php
@@ -25,15 +25,4 @@ trait HttpResponses
         // Redirect back to previous page
         return $this->successResponse ?? redirect()->back();
     }
-
-    /**
-     * Return the default error response.
-     *
-     * @return string
-     */
-    protected function failResponse(): string
-    {
-        // Return JS alert
-        return jsAlert($this->failMessage());
-    }
 }


### PR DESCRIPTION
- fix `CrudModelAction` to throw exceptions when actions fail in dev & prod environments
- cut sfneal/js-response-helpers & sfneal/laravel-helpers from composer dependencies